### PR TITLE
Removed check for probe when actually probing

### DIFF
--- a/src/ExternalResource.ts
+++ b/src/ExternalResource.ts
@@ -221,7 +221,7 @@ namespace Manifold {
                 }
 
                 // if the resource has a probe service, use that to get http status code
-                if (that.probeService && !that.isProbed) {
+                if (that.probeService) {
 
                     that.isProbed = true;
 

--- a/src/ExternalResource.ts
+++ b/src/ExternalResource.ts
@@ -228,7 +228,12 @@ namespace Manifold {
                     $.ajax(<JQueryAjaxSettings>{
                         url: that.probeService.id,
                         type: 'GET',
-                        dataType: 'json'
+                        dataType: 'json',
+                        beforeSend: (xhr) => {
+                            if (accessToken) {
+                                xhr.setRequestHeader("Authorization", "Bearer " + accessToken.accessToken);
+                            }
+                        }
                     }).done((data: any) => {
 
                         let contentLocation: string = unescape(data.contentLocation);


### PR DESCRIPTION
At the moment when requesting data from a resource, this function will use the probe in place of the main resource to check if the main resource is not authorised (i.e. detecting a redirect). However, this code can't be called twice with a probe service.

After hitting this code once, the `isProbed` becomes `true` and no longer uses the probe. The `else` condition in this function leads manifold to believe that this resource does not have a probe. The problem is that when we request a resource that has moved, like redacted, it will still return a 200 as if nothing was wrong (the problem the probe fixes). 

So this change makes it so that the probe service is ALWAYS called when requesting data to ensure that the correct authorisation information can be returned, especially if it changes between requests (user logging in in a window for example).

cc/ @edsilv @tomcrane @irv