### PR TITLE
Fix JSON parsing in xhr request

### DIFF
--- a/src/ExternalResource.ts
+++ b/src/ExternalResource.ts
@@ -444,14 +444,13 @@ export class ExternalResource implements IExternalResource {
         }
 
         xhr.onload = () => {
-          const data = JSON.parse(xhr.responseText);
-
           // if it's a resource without an info.json
           // todo: if resource doesn't have a @profile
-          if (!data) {
+          if (!xhr.responseText) {
             that.status = HTTPStatusCode.OK;
             resolve(that);
           } else {
+            const data = JSON.parse(xhr.responseText);
             let uri: string = unescape(data["@id"]);
 
             that.data = data;


### PR DESCRIPTION
While testing Avalon manifests in the latest UV app, we came across this issue. When UV tries to authenticate the auth services fails because it tries to parse an empty `responseText`. [Here](https://app.zenhub.com/workspaces/avalon-5bff96674b5806bc2bf90276/issues/avalonmediasystem/avalon/4130) is the relevant issue in Avalon.

Co-authored-by: Chris Colvard <cjcolvar@indiana.edu>