### PR TITLE
Updated manifest to 4.2.0 fixing breaking changes with languages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2603,12 +2603,12 @@
       "dev": true
     },
     "isomorphic-unfetch": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/isomorphic-unfetch/-/isomorphic-unfetch-3.0.0.tgz",
-      "integrity": "sha512-V0tmJSYfkKokZ5mgl0cmfQMTb7MLHsBMngTkbLY0eXvKqiVRRoZP04Ly+KhKrJfKtzC9E6Pp15Jo+bwh7Vi2XQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-unfetch/-/isomorphic-unfetch-3.1.0.tgz",
+      "integrity": "sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==",
       "requires": {
-        "node-fetch": "^2.2.0",
-        "unfetch": "^4.0.0"
+        "node-fetch": "^2.6.1",
+        "unfetch": "^4.2.0"
       }
     },
     "json-parse-better-errors": {
@@ -2735,9 +2735,9 @@
       "dev": true
     },
     "manifesto.js": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/manifesto.js/-/manifesto.js-4.0.1.tgz",
-      "integrity": "sha512-COHlq5zd+qWk7rP1iWAbSN9aMw+xPpSgKl9MVvvT3RP8J7mvY4wVsifyJTPdpJBV2k8hjjvACET/Qz2tzVwcqw==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/manifesto.js/-/manifesto.js-4.2.1.tgz",
+      "integrity": "sha512-kL1orNwVDb9x8xztXPHRl8CVsb2CL5NPvTauN/lNWFeB4P5Kv+u8daUHPgu4d/JuZ2ubFGS0EFqCpdUwy/jduA==",
       "requires": {
         "@edsilv/http-status-codes": "^1.0.3",
         "@iiif/vocabulary": "^1.0.11",
@@ -3010,9 +3010,9 @@
       "dev": true
     },
     "node-fetch": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
     "node-libs-browser": {
       "version": "2.2.1",
@@ -4348,9 +4348,9 @@
       }
     },
     "unfetch": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-4.1.0.tgz",
-      "integrity": "sha512-crP/n3eAPUJxZXM9T80/yv0YhkTEx2K1D3h7D1AJM6fzsWZrxdyRuLN0JH/dkZh1LNH8LxCnBzoPFCPbb2iGpg=="
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-4.2.0.tgz",
+      "integrity": "sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA=="
     },
     "union-value": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,6 @@
   "dependencies": {
     "@edsilv/http-status-codes": "^1.0.3",
     "@iiif/vocabulary": "^1.0.11",
-    "manifesto.js": "4.2.0"
+    "manifesto.js": "4.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "./dist-umd/manifold.js",
   "module": "./dist-esmodule/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./dist-esmodule/index.d.ts",
   "scripts": {
     "build:commonjs": "tsc",
     "build:docs": "rimraf -rf docs && typedoc --out docs --name manifold --theme default --ignoreCompilerErrors --experimentalDecorators --emitDecoratorMetadata --target ES6 --moduleResolution node --preserveConstEnums --stripInternal --suppressExcessPropertyErrors --suppressImplicitAnyIndexErrors --module commonjs src/ && touch docs/.nojekyll",
@@ -44,6 +44,6 @@
   "dependencies": {
     "@edsilv/http-status-codes": "^1.0.3",
     "@iiif/vocabulary": "^1.0.11",
-    "manifesto.js": "4.0.1"
+    "manifesto.js": "4.2.0"
   }
 }

--- a/src/Bootstrapper.ts
+++ b/src/Bootstrapper.ts
@@ -1,5 +1,5 @@
 import { Helper } from "./Helper";
-import { IIIFResourceType } from "@iiif/vocabulary";
+import { IIIFResourceType } from "@iiif/vocabulary/dist-commonjs";
 import { IManifoldOptions } from "./IManifoldOptions";
 import {
   Collection,

--- a/src/ExternalResource.ts
+++ b/src/ExternalResource.ts
@@ -1,4 +1,4 @@
-import { ServiceProfile } from "@iiif/vocabulary";
+import { ServiceProfile } from "@iiif/vocabulary/dist-commonjs";
 import * as HTTPStatusCode from "@edsilv/http-status-codes";
 import {
   Annotation,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,8 +19,9 @@
         "suppressImplicitAnyIndexErrors": true,
         "target": "es5",
         "types": [
-            "node", 
-            "manifesto.js"
+            "node",
+            "manifesto.js",
+            "@iiif/vocabulary"
         ]
     },
     "include": [


### PR DESCRIPTION
Removes the type hints that remained for `LanguageMap` which broke when building types. The interface is the compatible but cannot be cast due to the internal properties.

**Can wait until 4.2.1 when manifold changes come through.** 