### PR TITLE
Add test examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ https://iiif-commons.github.io/manifold/
     npm install
     npm run build
 
+### Testing the build
+The build can be run and tested in the browser console by running
+
+    npm start
+
+and navigating to examples/index.html.
+
 ### Publishing Package
 
     git checkout master

--- a/examples/index.html
+++ b/examples/index.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>Manifold Test</title>
+        <script src="../dist-umd/manifold.js"></script>
+        <style>
+        body {
+            font-family: Arial, sans-serif;
+            padding: 20px;
+        }
+        input, button {
+            padding: 10px;
+            font-size: 16px;
+            margin-top: 10px;
+        }
+        #output {
+            margin-top: 20px;
+            font-family: monospace;
+            white-space: pre-wrap;
+            word-wrap: break-word;
+            border: 1px solid #ccc;
+            padding: 10px;
+            background-color: #f5f5f5;
+        }
+    </style>
+    </head>
+    <body>
+        <h1>Manifold Test</h1>
+        <label for="manifest-url">Enter manifest URL to use the helper object
+            (manifoldHelper) in the console:</label><br>
+        <input type="text" id="manifest-url" size="50"
+            value="https://iiif.wellcomecollection.org/presentation/v2/b18035978">
+        <button onclick="loadManifest()">Load</button>
+
+        <div id="output"></div>
+
+        <script>
+        let manifoldHelper;
+
+        function loadManifest() {
+        const manifestUrl = document.getElementById("manifest-url").value;
+
+        if (!manifestUrl) {
+            alert("Please enter a valid IIIF manifest URL.");
+            return;
+        }
+
+        manifold
+            .loadManifest({
+                manifestUri: manifestUrl,
+                collectionIndex: 0,
+                manifestIndex: 0,
+                locale: "en",
+            })
+            .then(function (helper) {
+                console.log("manifoldHelper loaded");
+                manifoldHelper = helper;
+
+                // display the helper object in the output div
+                // document.getElementById('output').textContent = JSON.stringify(helper, null, 2);
+            })
+            .catch(function (error) {
+                console.error("Error loading manifest:", error);
+                alert("Error loading manifest. Check the console for details.");
+            });
+        }
+    </script>
+
+    </body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@types/jest": "^25.2.3",
         "jest": "^29",
         "jest-environment-jsdom": "^29.7.0",
-        "manifesto.js": "4.2.20",
+        "manifesto.js": "4.2.21",
         "ts-jest": "^29"
       },
       "devDependencies": {
@@ -6156,9 +6156,9 @@
       }
     },
     "node_modules/manifesto.js": {
-      "version": "4.2.20",
-      "resolved": "https://registry.npmjs.org/manifesto.js/-/manifesto.js-4.2.20.tgz",
-      "integrity": "sha512-6J09N3pC335QirVZMXBkp4Mfa9IthKfy1BtGCvyre59z5h4l6OCc62NsyDFCGaysZRyuZ7zY4uzT7xU1g8yVHg==",
+      "version": "4.2.21",
+      "resolved": "https://registry.npmjs.org/manifesto.js/-/manifesto.js-4.2.21.tgz",
+      "integrity": "sha512-C14J8zMSXlQaQjKR7KpIYEAXWquS2DtdxL8cFj1P2kc/ZJ5nWWmDUrthysVoQlRIzks5HtUNf5bStOwzhzarag==",
       "license": "MIT",
       "dependencies": {
         "@edsilv/http-status-codes": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "prepublishOnly": "npm run build",
-    "watch": "npm run build:esmodule -- --watch"
+    "watch": "npm run build:esmodule -- --watch",
+    "start": "npx serve"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@types/jest": "^25.2.3",
     "jest": "^29",
     "jest-environment-jsdom": "^29.7.0",
-    "manifesto.js": "4.2.20",
+    "manifesto.js": "4.2.21",
     "ts-jest": "^29"
   },
   "optionalDependencies": {


### PR DESCRIPTION
This adds an html input form so that any manifest can be tested in the console.
Also updates documentation with instructions.